### PR TITLE
Allow additional key maps to be imported

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -29,6 +29,8 @@ var app = new EmberAddon({
       'xml', 'xquery', 'yaml', 'z80'
     ],
 
+    keyMaps: ['emacs', 'sublime', 'vim'],
+
     themes: [
       '3024-day', '3024-night', 'ambiance-mobile', 'ambiance', 'base16-dark',
       'base16-light', 'blackboard', 'cobalt', 'eclipse', 'elegant',

--- a/README.md
+++ b/README.md
@@ -58,21 +58,22 @@ to as well:
 ### Themes / Modes
 
 By default, only `codemirror.css` (CodeMirror's default theme) is included. To
-include more themes and modes, add `codemirror` options to `Brocfile.js` inside
+include more themes, modes, and key maps, add `codemirror` options to `Brocfile.js` inside
 your app:
 
 ```js
 var app = new EmberApp({
   codemirror: {
     modes: ['javascript'],
+    keyMaps: ['vim'],
     themes: ['solarized']
   }
 });
 ```
 
-The above example would pull in `mode/javascript/javascript.js` and
-`theme/solarized.css` from CodeMirror and add them to `vendor.js` and
-`vendor.css`, respectively.
+The above example would pull in `mode/javascript/javascript.js`,
+`keymap/vim.js`, `theme/solarized.css` from CodeMirror and add them to
+`vendor.js` and `vendor.css`, respectively.
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = {
   included: function(app) {
     var options = app.options.codemirror || {};
     var modes = options.modes || [];
+    var keyMaps = options.keyMaps || [];
     var themes = options.themes || [];
 
     app.import(app.bowerDirectory + '/codemirror/lib/codemirror.css');
@@ -14,6 +15,10 @@ module.exports = {
 
     modes.forEach(function(mode) {
       app.import(app.bowerDirectory + '/codemirror/mode/' + mode + '/' + mode + '.js');
+    });
+
+    keyMaps.forEach(function(keyMap) {
+      app.import(app.bowerDirectory + '/codemirror/keymap/' + keyMap + '.js');
     });
 
     themes.forEach(function(theme) {

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -5,6 +5,7 @@ export default Ember.Controller.extend({
   lineNumbers: true,
   lineWrapping: false,
   mode: 'javascript',
+  keyMap: 'basic',
   readOnly: false,
   smartIndent: true,
   tabSize: 4,
@@ -25,6 +26,8 @@ export default Ember.Controller.extend({
     'toml', 'tornado', 'turtle', 'vb', 'vbscript', 'velocity', 'verilog',
     'xml', 'xquery', 'yaml', 'z80'
   ]),
+
+  keyMaps: Ember.A(['basic', 'emacs', 'sublime', 'vim']),
 
   themes: Ember.A([
     '3024-day', '3024-night', 'ambiance-mobile', 'ambiance', 'base16-dark',

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -2,13 +2,26 @@
 
 <div class="row">
   <div class="col-sm-9">
-    {{ivy-codemirror lineNumbers=lineNumbers lineWrapping=lineWrapping mode=mode readOnly=readOnly smartIndent=smartIndent theme=theme value=value}}
+    {{ivy-codemirror
+      lineNumbers=lineNumbers
+      lineWrapping=lineWrapping
+      mode=mode
+      keyMap=keyMap
+      readOnly=readOnly
+      smartIndent=smartIndent
+      theme=theme
+      value=value}}
   </div>
 
   <div class="col-sm-3">
     <div class="form-group">
       <label class="control-label" for="mode">Mode</label>
       {{view "select" class="form-control" content=modes id="mode" value=mode}}
+    </div>
+
+    <div class="form-group">
+      <label class="control-label" for="key-map">Key map</label>
+      {{view "select" class="form-control" content=keyMaps id="key-map" value=keyMap}}
     </div>
 
     <div class="form-group">


### PR DESCRIPTION
This allows additional key maps (emacs, vim, sublime) to be imported by specifying an additional option in your `Brocfile.js`, similar to how themes and modes work.