### PR TITLE
Update ivy-codemirror.js

### DIFF
--- a/addon/components/ivy-codemirror.js
+++ b/addon/components/ivy-codemirror.js
@@ -143,8 +143,10 @@ export default Ember.Component.extend({
    */
   _updateValue: function(instance) {
     var value = instance.getValue();
-    this.set('value', value);
-    this.sendAction('valueUpdated', value);
+    if (value !== this.get('value')) {
+      this.set('value', value);
+      this.sendAction('valueUpdated', value);
+    }
   },
 
   _valueDidChange: function() {


### PR DESCRIPTION
If you check that the mirror instance's value is new then you prevent false valueUpdated actions when the value is first loaded or updated from the back-end.
