### PR TITLE
pass all event params to sendAction

### DIFF
--- a/addon/components/ivy-codemirror.js
+++ b/addon/components/ivy-codemirror.js
@@ -141,10 +141,10 @@ export default Ember.Component.extend({
    * @private
    * @method _updateValue
    */
-  _updateValue: function(instance) {
+  _updateValue: function(instance, changeObj) {
     var value = instance.getValue();
     this.set('value', value);
-    this.sendAction('valueUpdated', value);
+    this.sendAction('valueUpdated', value, instance, changeObj);
   },
 
   _valueDidChange: function() {

--- a/bower.json
+++ b/bower.json
@@ -5,13 +5,13 @@
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.7",
+    "ember-qunit": "0.4.18",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "codemirror": "~5.3.0",
     "bootstrap": "~3.3.1",
-    "qunit": "~1.17.1"
+    "qunit": "^1.20.0"
   }
 }


### PR DESCRIPTION
Hey, this PR passes the CodeMirror event arguments to the `valueUpdated` action. I think this can come in handy when building apps with this component. It is also needed to fix an [issue](https://github.com/ember-cli/ember-twiddle/issues/290) in Ember Twiddle.