### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ to as well:
 ### Themes / Modes
 
 By default, only `codemirror.css` (CodeMirror's default theme) is included. To
-include more themes, modes, and key maps, add `codemirror` options to `Brocfile.js` inside
+include more themes, modes, and key maps, add `codemirror` options to `ember-cli-build.js` inside
 your app:
 
 ```js


### PR DESCRIPTION
DEPRECATION: Brocfile.js has been deprecated in favor of ember-cli-build.js. Please see the transition guide: https://github.com/ember-cli/ember-cli/blob/master/TRANSITION.md#user-content-brocfile-transition.