### PR TITLE
Add mapping of CodeMirror events to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ However, for this simple use case, Ember provides the built-in `mut` helper. You
 {{ivy-codemirror value=myCode valueUpdated=(action (mut myCode))}}
 ```
 
+### Events
+
+In addition to the default `valueUpdated` action provided, you can also listen for arbitrary CodeMirror editor [events](http://codemirror.net/doc/manual.html#events) yourself, by passing `events` to the `ivy-codemirror` component, like so:
+
+```handlebars
+{{ivy-codemirror events=(hash change=(action "onChange"))}}
+```
+
+This would cause the `onChange` action to be sent whenever a CodeMirror `change` event occurs, passing along any arguments.
+
+Note that **these action handlers are unbound**. They are added once, during `didInsertElement`. Changing the `events` hash after that will not cause the action handlers to be updated.
+
 ### Options
 
 `ivy-codemirror` also allows passing [options](http://codemirror.net/doc/manual.html#config) to CodeMirror via the `options` property. The easiest way to do this is via Ember's built-in `hash` helper, like so:

--- a/addon/components/ivy-codemirror.js
+++ b/addon/components/ivy-codemirror.js
@@ -22,6 +22,14 @@ export default Component.extend({
 
     // Send a "valueUpdated" action when CodeMirror triggers a "change" event.
     this.setupCodeMirrorEventHandler('change', this, this.scheduleValueUpdatedAction);
+
+    const events = this.get('events');
+
+    if (events) {
+      Object.keys(events).forEach(function(eventName) {
+        this.setupCodeMirrorEventHandler(eventName, this, events[eventName]);
+      }, this);
+    }
   },
 
   didRender() {

--- a/tests/integration/components/ivy-codemirror-test.js
+++ b/tests/integration/components/ivy-codemirror-test.js
@@ -1,5 +1,6 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import CodeMirror from 'codemirror';
 import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent, test } from 'ember-qunit';
 
 moduleForComponent('ivy-codemirror', 'Integration | Component | ivy-codemirror', {
   integration: true,
@@ -21,13 +22,36 @@ test('it uses the `value` property to set the value of the CodeMirror instance',
 });
 
 test('it sends a "valueUpdated" action when the value of the CodeMirror instance changes', function(assert) {
-  this.render(hbs`{{ivy-codemirror id="ivy-codemirror-tests" valueUpdated=(action (mut value)) value=value}}`);
+  assert.expect(1);
+
+  this.on('valueUpdated', function(value) {
+    assert.strictEqual(value, '2');
+  });
+
+  this.render(hbs`{{ivy-codemirror id="ivy-codemirror-tests" valueUpdated=(action "valueUpdated") value=value}}`);
   const instance = this.codeMirror.instanceFor('ivy-codemirror-tests');
 
   instance.setValue('2');
-  this.codeMirror.signal(instance, 'change', instance);
+});
 
-  assert.equal(this.get('value'), '2');
+test('it maps a CodeMirror "change" event to an action via the `events` property', function(assert) {
+  assert.expect(2);
+
+  this.on('onChange', function(instance, changeObj) {
+    assert.ok(instance instanceof CodeMirror, '1st argument is the CodeMirror instance');
+    assert.propEqual(changeObj, {
+      from: { ch: 0, line: 0 },
+      origin: 'setValue',
+      removed: [''],
+      text: ['2'],
+      to: { ch: 0, line: 0 }
+    }, '2nd argument is the change object');
+  });
+
+  this.render(hbs`{{ivy-codemirror events=(hash change=(action "onChange")) id="ivy-codemirror-tests" value=value}}`);
+  const instance = this.codeMirror.instanceFor('ivy-codemirror-tests');
+
+  instance.setValue('2');
 });
 
 test('it refreshes when the `isVisible` property becomes true', function(assert) {


### PR DESCRIPTION
This adds an `events` property which allows you to declaratively set up CodeMirror event handlers from your templates, like so:

``` handlebars
{{ivy-codemirror events=(hash change=(action "onChange"))}}
```

The `onChange` action would then be invoked whenever a CodeMirror `change` event occurs, passing along any arguments from CodeMirror. For now I'm assuming that `events` is unbound, so changing it after the initial render would not cause the event handlers to be updated.
