### PR TITLE
CodeMirror addon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ var app = new EmberApp({
 
 The example above would include `mode/javascript/javascript.js` and `keymap/vim.js` into `vendor.js`.
 
+### Addons
+
+In addition to the above, you can also include any CodeMirror addon files like so:
+
+```js
+var app = new EmberApp({
+  codemirror: {
+    addonFiles: ['lint/lint.css', 'lint/lint.js']
+  }
+});
+```
+
+The above example would add `lint/lint.css` to `vendor.css` and `lint/lint.js` to `vendor.js`.
+
 ## Contributing
 
 Fork this repo, make a new branch, and send a pull request. Make sure your change is tested or it won't be merged.

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,10 @@ const path = require('path');
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     codemirror: {
+      addonFiles: [
+        'selection/active-line.js'
+      ],
+
       modes: [
         'apl',
         'asciiarmor',

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -10,6 +10,7 @@
         keyMap=keyMap
         readOnly=readOnly
         smartIndent=smartIndent
+        styleActiveLine=styleActiveLine
         theme=theme
       )
       value=value
@@ -66,6 +67,12 @@
     <div class="checkbox">
       <label>
         {{input checked=smartIndent type="checkbox"}} Smart indent
+      </label>
+    </div>
+
+    <div class="checkbox">
+      <label>
+        {{input checked=styleActiveLine type="checkbox"}} Style active line
       </label>
     </div>
   </div>


### PR DESCRIPTION
This PR allows you to pull in CodeMirror addon files to your build. Note that since addons are relatively unstructured, we can't make assumptions about how they're organized. As a result, you must specify the file extension as well, like so:

```js
// ember-cli-build.js
var app = new EmberApp({
  codemirror: {
    addonFiles: ['lint/lint.css', 'lint/lint.js']
  }
});
```