### PR TITLE
Prefer closure actions but support traditional sendAction

### DIFF
--- a/addon/components/ivy-codemirror.js
+++ b/addon/components/ivy-codemirror.js
@@ -47,7 +47,13 @@ export default Component.extend({
   },
 
   sendValueUpdatedAction(...args) {
-    this.sendAction('valueUpdated', ...args); // eslint-disable-line ember/closure-actions
+    const valueUpdated = this.get('valueUpdated');
+    if (typeof valueUpdated === 'function') {
+      valueUpdated(...args);
+    } else if (valueUpdated) {
+      // DEPRECATED: sendAction is deprecated as of Ember 3.4
+      this.sendAction('valueUpdated', ...args); // eslint-disable-line ember/closure-actions
+    }
   },
 
   toggleVisibility() {

--- a/tests/integration/components/ivy-codemirror-test.js
+++ b/tests/integration/components/ivy-codemirror-test.js
@@ -30,6 +30,18 @@ test('it sends a "valueUpdated" action when the value of the CodeMirror instance
   assert.equal(this.get('value'), '2');
 });
 
+test('the "valueUpdated" action works using string-based actions for backwards compatability', function(assert) {
+  this.on('setValue', val => this.set('value', val));
+
+  this.render(hbs`{{ivy-codemirror id="ivy-codemirror-tests" valueUpdated="setValue" value=value}}`);
+  const instance = this.codeMirror.instanceFor('ivy-codemirror-tests');
+
+  instance.setValue('2');
+  this.codeMirror.signal(instance, 'change', instance);
+
+  assert.equal(this.get('value'), '2');
+});
+
 test('it refreshes when the `isVisible` property becomes true', function(assert) {
   this.render(hbs`{{ivy-codemirror id="ivy-codemirror-tests" isVisible=isVisible}}`);
   const instance = this.codeMirror.instanceFor('ivy-codemirror-tests');


### PR DESCRIPTION
Since sendAction has been deprecated since Ember 3.4, addons shouldn't use it. 

Instead of replacing the one call to `sendAction` with an assumed closure action, this approach maintains backwards compatibility. So no one who runs `ember install ivy-codemirror` has to think about their ember version.

Once Ember 4 lands and the `sendAction` method is gone entirely, this addon can safely assume a closure action as well.

Fixes #39 